### PR TITLE
Mask vertex normals after seam repair.

### DIFF
--- a/src/repair/seam_detection.rs
+++ b/src/repair/seam_detection.rs
@@ -1,4 +1,5 @@
 use crate::land::grid_access::Index2D;
+use crate::land::landscape_diff::LandscapeDiff;
 use crate::land::terrain_map::Vec2;
 use crate::merge::relative_terrain_map::RelativeTerrainMap;
 use crate::LandmassDiff;
@@ -319,6 +320,17 @@ pub fn repair_landmass_seams(merged: &mut LandmassDiff) -> usize {
                 seam.3,
                 seam.4
             );
+        }
+    }
+
+    for land in merged.land.values_mut() {
+        if let Some(vertex_normals) = land.vertex_normals.as_ref() {
+            land.vertex_normals = Some(LandscapeDiff::apply_mask(
+                vertex_normals,
+                land.height_map
+                    .as_ref()
+                    .map(RelativeTerrainMap::differences),
+            ));
         }
     }
 


### PR DESCRIPTION
Issue #6 & #7 are a panic in `recompute_vertex_normals` caused by vertex normal differences that still exist after height map differences have been removed.

When height maps are merged, we mask out vertex normals if the height map difference is unchanged.
At that point in time, the invariant is true.

However, we later repair seams by adjusting height map differences along seam boundaries.

If a seam is repaired such that it ends up at the exact same height as the original height map, and there existed a vertex normal difference at that same coordinate, we will panic when we later enter `recompute_vertex_normals`.

This PR attempts to fix the crash by re-masking vertex normals after seam repair.
I say "attempts" because I've been unable to repro the crash myself.